### PR TITLE
Leftovers for the reporting and default values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # CUSTOM changes
 .idea/
+.vscode/
 .memory
 results/
 .gradle
@@ -14,4 +15,5 @@ htmlcov/
 *.pyc
 __pycache__/
 venv
+.venv
 dist

--- a/src/core/en_opt.py
+++ b/src/core/en_opt.py
@@ -238,7 +238,7 @@ class Entropy:
 
         res_report.set_seq_len(seq_len)
         res_report.set_window_size(window_size)
-        res_report.set_step_size(step_size)
+        res_report.set_step_size(step_size if step_size else 0)
         res_report.set_avg_rr(average_rr_list)
         res_report.set_result_values(en_results)
 

--- a/src/core/report.py
+++ b/src/core/report.py
@@ -314,7 +314,7 @@ class ReportManager:
         return column_names
 
     @staticmethod
-    def prepare_header(analysis_types, res_dic):
+    def prepare_header(analysis_types, res_dic: dict):
         header_lines = [
             ['Analysis applied', *analysis_types],
         ]
@@ -327,17 +327,24 @@ class ReportManager:
             dimension = 'error'
         header_lines.append(['Dimension', dimension])
 
+        any_report_per_file = [res_dic[i][0] for i in res_dic.keys()]
         try:
-            length = any_report.get_seq_len()
+            min_length = min(map(lambda x: x.get_seq_len(), any_report_per_file))
         except AttributeError:
-            length = 'error'
-        header_lines.append(['Number of points', length])
+            min_length = 'error'
+        header_lines.append(['Minimum number of points', min_length])
+
+        try:
+            max_length = max(map(lambda x: x.get_seq_len(), any_report_per_file))
+        except AttributeError:
+            max_length = 'error'
+        header_lines.append(['Maximum number of points', max_length])
 
         try:
             window_size = any_report.get_window_size()
         except AttributeError:
             window_size = 'error'
-        header_lines.append(['Window size', window_size])
+        header_lines.append(['Window size', window_size if window_size else 'full sequence length'])
 
         try:
             step_size = any_report.get_step_size()

--- a/src/gui/widgets/ap_en_widget.py
+++ b/src/gui/widgets/ap_en_widget.py
@@ -163,6 +163,7 @@ class ApEnWidget(QWidget):
         self.progress_bar.setValue(val if val < 100 else 0)
 
     def show_message(self, source, file_names, report_path=None):
+        self.ok_button = QPushButton('Ok', self)
         self.dialog = QMessageBox(self)
         self.dialog.setWindowModality(False)
         all_files = "".join(["- {} \n".format(i) for i in file_names.split(',')])
@@ -170,6 +171,7 @@ class ApEnWidget(QWidget):
         if report_path:
             dialog_text += '\n Saved report in {}'.format(report_path)
         self.dialog.setText(dialog_text)
+        self.dialog.setDefaultButton(self.ok_button)
         self.dialog.show()
 
     def set_in_progress(self, v):

--- a/src/gui/widgets/ap_en_widget.py
+++ b/src/gui/widgets/ap_en_widget.py
@@ -229,7 +229,7 @@ class ApEnWidget(QWidget):
         return fd_max_k
 
     def get_window_size(self):
-        return int(self.window_analysis_widget.get_window_size()) if self.is_windows_enabled else 0
+        return int(self.window_analysis_widget.get_window_size()) if self.is_windows_enabled else None
 
     def get_step_size(self):
-        return int(self.window_analysis_widget.get_window_step()) if self.is_windows_enabled else 0
+        return int(self.window_analysis_widget.get_window_step()) if self.is_windows_enabled else None

--- a/src/gui/widgets/ap_en_widget.py
+++ b/src/gui/widgets/ap_en_widget.py
@@ -184,6 +184,8 @@ class ApEnWidget(QWidget):
         self.is_calc_ent = not self.is_calc_ent
         self.ent_widget.set_ap_en(self.is_calc_ent)
         self.ent_widget.set_samp_en(self.is_calc_ent)
+        if not self.is_calc_ent:
+            self.ent_widget.reset_to_default()
         self.check_run_button_state()
         self.ent_widget.setHidden(not self.is_calc_ent)
 
@@ -191,6 +193,8 @@ class ApEnWidget(QWidget):
         self.is_calc_pertropy = not self.is_calc_pertropy
         self.check_run_button_state()
         self.pertropy_widget.setHidden(not self.is_calc_pertropy)
+        if not self.is_calc_pertropy:
+            self.pertropy_widget.reset_to_default()
 
     def toggle_window_checkbox(self):
         self.is_windows_enabled = not self.is_windows_enabled

--- a/src/gui/widgets/entropy_widget.py
+++ b/src/gui/widgets/entropy_widget.py
@@ -43,10 +43,10 @@ class EntropyWidget(QWidget):
         self.samp_en_cb.setChecked(self.is_samp_en_used)
         self.samp_en_cb.clicked.connect(self.toggle_samp_en_cb)
 
-        cb = QCheckBox('Use threshold', self)
+        self.threshold_cb = QCheckBox('Use threshold', self)
         self.is_threshold_used = True
-        cb.setChecked(self.is_threshold_used)
-        cb.clicked.connect(self.toggle_threshold_checkbox)
+        self.threshold_cb.setChecked(self.is_threshold_used)
+        self.threshold_cb.clicked.connect(self.toggle_threshold_checkbox)
 
         descr = 'threshold (minumum number<br>of elements in a sequence)'
         self.r_threshold_label = QLabel('<p style="text-align:right">{}</p>'.format(descr))
@@ -56,7 +56,7 @@ class EntropyWidget(QWidget):
         number_group = self.config_r_enth_group()
 
         grid = QGridLayout()
-        grid.addWidget(cb, 0, 0, 1, 2)
+        grid.addWidget(self.threshold_cb, 0, 0, 1, 2)
         grid.addWidget(self.r_threshold_label, 1, 0)
         grid.addWidget(self.r_threshold, 1, 1)
 
@@ -85,9 +85,11 @@ class EntropyWidget(QWidget):
 
     def toggle_ap_en_cb(self):
         self.is_ap_en_used = not self.is_ap_en_used
+        self.ap_en_cb.setChecked(self.is_ap_en_used)
 
     def toggle_samp_en_cb(self):
         self.is_samp_en_used = not self.is_samp_en_used
+        self.samp_en_cb.setChecked(self.is_samp_en_used)
 
     def is_samp_en(self):
         return self.is_samp_en_used
@@ -97,9 +99,11 @@ class EntropyWidget(QWidget):
 
     def set_samp_en(self, v):
         self.is_samp_en_used = v
+        self.samp_en_cb.setChecked(self.is_samp_en_used)
 
     def set_ap_en(self, v):
         self.is_ap_en_used = v
+        self.ap_en_cb.setChecked(self.is_ap_en_used)
 
     def get_threshold(self):
         return int(self.r_threshold.text()) if self.is_threshold_used else -1
@@ -113,3 +117,9 @@ class EntropyWidget(QWidget):
     def is_threshold(self):
         return self.is_threshold_used
 
+    def reset_to_default(self):
+        self.set_ap_en(True)
+        self.set_samp_en(True)
+        self.r_threshold.setText('300')
+        self.r_threshold.setEnabled(True)
+        self.threshold_cb.setChecked(True)

--- a/src/gui/widgets/entropy_widget.py
+++ b/src/gui/widgets/entropy_widget.py
@@ -43,7 +43,7 @@ class EntropyWidget(QWidget):
         self.samp_en_cb.setChecked(self.is_samp_en_used)
         self.samp_en_cb.clicked.connect(self.toggle_samp_en_cb)
 
-        self.threshold_cb = QCheckBox('Use threshold', self)
+        self.threshold_cb = QCheckBox('Check for threshold', self)
         self.is_threshold_used = True
         self.threshold_cb.setChecked(self.is_threshold_used)
         self.threshold_cb.clicked.connect(self.toggle_threshold_checkbox)

--- a/src/gui/widgets/pertropy_widget.py
+++ b/src/gui/widgets/pertropy_widget.py
@@ -51,3 +51,8 @@ class PertropyWidget(QWidget):
         except:
             pass
         return res
+
+    def reset_to_default(self):
+        self.normalize_cb.setChecked(True)
+        self.is_stride_used = True
+        self.toggle_stride_checkbox()

--- a/tests/gui/apen_isolated_test_e2e.py
+++ b/tests/gui/apen_isolated_test_e2e.py
@@ -80,3 +80,54 @@ def test_apen_w_windows_ideal_seq(qtbot):
     test_app.wait_until_calculation_is_done()
     path = test_app.check_modal_not_error()
     check_report(path)
+
+
+def test_apen_wo_windows_resetting_state(qtbot):
+    """
+    Known issue was that for the steps:
+        1. deselect all items except ApEn/SampEn
+        2. deselect ApEn (leave only SampEn)
+        3. change threshold value
+        4. press calculate - we get only SampEn calculated
+        5. deselect ApEn/SampEn entropy completely
+        6. select it again
+        7. everything should be selected (that was the issue - checkboxes
+            did not represent the actual state)
+        8. press calculate - we get both ApEn/SampEn calculated
+    """
+    window = App()
+    qtbot.addWidget(window)
+
+    test_app = ApEnTestingBed(qtbot=qtbot, window=window)
+
+    qtbot.waitForWindowShown(window)
+
+    # disable windows and others
+    test_app.press_windows_cb()
+    test_app.press_pertropy_cb()
+    test_app.press_cordim_cb()
+    test_app.press_fracdim_cb()
+
+    # disable ApEn
+    test_app.press_apen_cb()
+
+    test_app.enter_new_threshold('20')
+    test_app.press_threshold_cb()
+
+    assert not test_app.calculate_btn_state()
+    test_app.choose_zero_deviation_file()
+
+    assert test_app.calculate_btn_state()
+    test_app.press_calculate_btn()
+
+    test_app.wait_until_calculation_is_done()
+    path = test_app.check_modal_not_error()
+    check_report(path)
+
+    test_app.close_calculation_dialog()
+    test_app.press_common_sampen_apen_cb()
+    test_app.press_common_sampen_apen_cb()
+    assert test_app.is_apen_selected()
+    assert test_app.is_sampen_selected()
+    assert test_app.is_threshold_selected()
+    assert test_app.is_threshold_text('300')

--- a/tests/gui/apen_isolated_test_e2e.py
+++ b/tests/gui/apen_isolated_test_e2e.py
@@ -78,7 +78,7 @@ def test_apen_w_windows_ideal_seq(qtbot):
     test_app.press_calculate_btn()
 
     test_app.wait_until_calculation_is_done()
-    path = test_app.check_modal_not_error()
+    path = test_app.check_custom_modal_not_error(['ApEn'])
     check_report(path)
 
 
@@ -121,7 +121,7 @@ def test_apen_wo_windows_resetting_state(qtbot):
     test_app.press_calculate_btn()
 
     test_app.wait_until_calculation_is_done()
-    path = test_app.check_modal_not_error()
+    path = test_app.check_custom_modal_not_error(['SampEn'])
     check_report(path)
 
     test_app.close_calculation_dialog()

--- a/tests/gui/app_testing_bed.py
+++ b/tests/gui/app_testing_bed.py
@@ -15,6 +15,9 @@ class AppTestingBed:
     def press_windows_cb(self):
         self._click(self.window.table_widget.window_cb)
 
+    def press_common_sampen_apen_cb(self):
+        self._click(self.window.table_widget.is_use_ent_cb)
+
     def press_apen_cb(self):
         self._click(self.window.table_widget.ent_widget.ap_en_cb)
 
@@ -71,44 +74,58 @@ class AppTestingBed:
     def check_modal_not_error(self) -> str:
         raise NotImplementedError
 
+    def enter_new_threshold(self, text):
+        self.window.table_widget.ent_widget.r_threshold.setText(text)
+
+    def press_threshold_cb(self):
+        self._click(self.window.table_widget.ent_widget.threshold_cb)
+    
+    def check_custom_modal_not_error(self, options):
+        text = self.window.table_widget.dialog.text()
+        to_check = list(itertools.permutations(options))
+        res_check = ['{} calculated for'.format(','.join(i)) in text for i in to_check]
+        assert any(res_check)
+        assert 'Saved report in' in text
+        return text.split('Saved report in')[1].strip()
+
+    def close_calculation_dialog(self):
+        self._click(self.window.table_widget.ok_button)
+    
+    def is_apen_selected(self):
+        return self.window.table_widget.ent_widget.ap_en_cb.isChecked()
+    
+    def is_sampen_selected(self):
+        return self.window.table_widget.ent_widget.samp_en_cb.isChecked()
+    
+    def is_threshold_selected(self):
+        cb = self.window.table_widget.ent_widget.threshold_cb
+        return cb.isChecked() and cb.isEnabled()
+    
+    def is_threshold_text(self, text):
+        return self.window.table_widget.ent_widget.r_threshold.text() == text
+    
+
 
 class SampleEnTestingBed(AppTestingBed):
     def check_modal_not_error(self):
-        text = self.window.table_widget.dialog.text()
-        assert 'SampEn calculated for' in text
-        assert 'Saved report in' in text
-        return text.split('Saved report in')[1].strip()
+        return self.check_custom_modal_not_error(['SampEn'])
 
 
 class ApEnTestingBed(AppTestingBed):
     def check_modal_not_error(self):
-        text = self.window.table_widget.dialog.text()
-        assert 'ApEn calculated for' in text
-        assert 'Saved report in' in text
-        return text.split('Saved report in')[1].strip()
+        return self.check_custom_modal_not_error(['ApEn'])
 
 
 class ComboApEnSampEnTestingBed(AppTestingBed):
     def check_modal_not_error(self):
-        text = self.window.table_widget.dialog.text()
-        assert 'ApEn,SampEn calculated for' in text or 'SampEn,ApEn calculated for' in text
-        assert 'Saved report in' in text
-        return text.split('Saved report in')[1].strip()
+        return self.check_custom_modal_not_error(['ApEn', 'SampEn'])
 
 
 class ComboApEnSampEnPermEnTestingBed(AppTestingBed):
     def check_modal_not_error(self):
-        text = self.window.table_widget.dialog.text()
-        combos = list(itertools.permutations(['ApEn', 'SampEn', 'PermEn']))
-        existed = ['{} calculated for'.format(','.join(sub)) in text for sub in combos]
-        assert any(existed)
-        assert 'Saved report in' in text
-        return text.split('Saved report in')[1].strip()
+        return self.check_custom_modal_not_error(['ApEn', 'SampEn', 'PermEn'])
 
 
 class PermEnTestingBed(AppTestingBed):
     def check_modal_not_error(self):
-        text = self.window.table_widget.dialog.text()
-        assert 'PermEn calculated for' in text
-        assert 'Saved report in' in text
-        return text.split('Saved report in')[1].strip()
+        return self.check_custom_modal_not_error(['PermEn'])


### PR DESCRIPTION
1. ApEn widget does not store defaults when enabling/disabling it with a checkbox
2. Report contains incorrect window values when it is not used as well as sporadic length of sequences